### PR TITLE
Fix FlashOptim FSDP2 checkpoint serialization

### DIFF
--- a/flashoptim/optimizers.py
+++ b/flashoptim/optimizers.py
@@ -622,19 +622,6 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
             return tensor.to_local()
         return tensor
 
-    @classmethod
-    def _state_key_token(cls, tensor: torch.Tensor) -> tuple[int, int]:
-        """Build a stable token for matching optimizer state to current params.
-
-        FSDP2 can swap optimizer param-group entries to new DTensor objects whose
-        local shards alias the same storage. Matching only on Python object id is
-        too strict for checkpoint export, while matching only on storage pointer
-        is too loose for non-tensor keys. We use both local shard pointer and
-        numel to keep the matching stable across these rewrites.
-        """
-        local = cls._get_local_tensor(tensor)
-        return (local.data_ptr(), local.numel())
-
     @staticmethod
     def _wrap_state_as_dtensor(state: dict[str, Any], param: torch.Tensor) -> None:
         """Wrap plain state tensors as DTensors matching param's distribution.
@@ -899,9 +886,6 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         hparams: dict[str, Any],
         idx_to_param: dict[int, torch.Tensor],
     ) -> dict[str, Any]:
-        if param_number not in opt_state:
-            return {}
-
         # Make a copy so that we don't mutate our self.state. `opt_state`
         # isn't the same as self.state, but its consituent dicts are
         # the same as those in self.state; i.e., `opt_state[p] is self.state[p]`
@@ -989,39 +973,9 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         super().__setstate__(state)
 
     def state_dict(self):
-        for pre_hook in self._optimizer_state_dict_pre_hooks.values():
-            pre_hook(self)
-
-        param_mappings: dict[int, int] = {}
-        param_tokens: dict[tuple[int, int], int] = {}
-        start_index = 0
-
-        def pack_group(group: dict[str, Any]) -> dict[str, Any]:
-            nonlocal start_index
-            packed = {k: v for k, v in group.items() if k != "params"}
-            packed_params = []
-            for p in group["params"]:
-                idx = param_mappings.setdefault(id(p), start_index)
-                param_tokens.setdefault(self._state_key_token(p), idx)
-                packed_params.append(idx)
-                if idx == start_index:
-                    start_index += 1
-            packed["params"] = packed_params
-            return packed
-
-        param_groups = [pack_group(g) for g in self.param_groups]
-        opt_state = {}
-
-        for key, value in self.state.items():
-            if isinstance(key, torch.Tensor):
-                idx = param_mappings.get(id(key))
-                if idx is None:
-                    idx = param_tokens.get(self._state_key_token(key))
-                if idx is None:
-                    continue
-                opt_state[idx] = value
-            else:
-                opt_state[key] = value
+        d = super().state_dict()
+        opt_state = d["state"]
+        param_groups = d["param_groups"]
 
         # Build param index -> param mapping without mutating self.state
         idx_to_param: dict[int, torch.Tensor] = {}
@@ -1034,25 +988,14 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
                 assert isinstance(param_number, int)
                 if param_number not in opt_state:
                     continue  # frozen or pre-first-step param, no optimizer state
-                param_state = self._state_dict_for_param(
+                opt_state[param_number] = self._state_dict_for_param(
                     param_number,
                     opt_state=opt_state,
                     hparams=group,
                     idx_to_param=idx_to_param,
                 )
-                if param_state:
-                    opt_state[param_number] = param_state
 
-        state_dict = {
-            "state": opt_state,
-            "param_groups": param_groups,
-        }
-
-        for post_hook in self._optimizer_state_dict_post_hooks.values():
-            hook_result = post_hook(self, state_dict)
-            if hook_result is not None:
-                state_dict = hook_result
-        return state_dict
+        return d
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Load optimizer state, ensuring backward compatibility with vanilla PyTorch optimizers.

--- a/flashoptim/optimizers.py
+++ b/flashoptim/optimizers.py
@@ -629,16 +629,6 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         DCP requires optimizer state tensors to carry the same DTensor metadata
         (mesh, placements) as their corresponding parameters. Without this,
         DCP treats local shards as replicated data and scrambles them on load.
-
-        For state tensors whose local shape matches the param's local shape
-        (e.g. uncompressed momentum/variance), we pass ``shape`` and ``stride``
-        explicitly so wrapping is correct for both even and uneven shards —
-        ``DTensor.from_local``'s default global-shape inference (which
-        multiplies each sharded dim's local size by its mesh-dim size) is only
-        right for even splits. For tensors with a different layout (e.g.
-        quantized state, which has its own packed shape), we fall back to
-        default inference; that path is only correct for even shards, which
-        is a known limitation outside this function's scope.
         """
         if not hasattr(param, "device_mesh"):
             return
@@ -648,23 +638,41 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         placements = param.placements
         param_local_shape = param.to_local().shape
 
+        uneven = any(
+            param.shape[p.dim] % mesh.size(i) != 0
+            for i, p in enumerate(placements)
+            if hasattr(p, "dim")
+        )
+
         for key, val in state.items():
-            if (
+            if not (
                 isinstance(val, torch.Tensor)
                 and not isinstance(val, DTensor)
                 and val.dim() > 0
             ):
-                if val.shape == param_local_shape:
-                    state[key] = DTensor.from_local(
-                        val,
-                        mesh,
-                        placements,
-                        shape=param.shape,
-                        stride=param.stride(),
-                        run_check=False,
-                    )
-                else:
-                    state[key] = DTensor.from_local(val, mesh, placements)
+                continue
+            if val.shape == param_local_shape:
+                # Pass explicit shape/stride so wrapping is correct on uneven shards.
+                state[key] = DTensor.from_local(
+                    val,
+                    mesh,
+                    placements,
+                    shape=param.shape,
+                    stride=param.stride(),
+                    run_check=False,
+                )
+            elif uneven:
+                # e.g. quantized state with a packed shape: default inference
+                # would scramble DCP on uneven shards, and we have no global
+                # shape for this layout. Fail loudly rather than silently.
+                raise ValueError(
+                    f"Cannot safely wrap state tensor {key!r} of shape "
+                    f"{tuple(val.shape)} as a DTensor for unevenly-sharded "
+                    f"param of shape {tuple(param.shape)}: its layout does "
+                    f"not match the param, so the global shape is unknown."
+                )
+            else:
+                state[key] = DTensor.from_local(val, mesh, placements)
 
     def _recompute_stats_for_param(self, p: torch.Tensor) -> None:
         p_for_stats = self._get_tensor_for_stats(p)

--- a/flashoptim/optimizers.py
+++ b/flashoptim/optimizers.py
@@ -629,6 +629,13 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         DCP requires optimizer state tensors to carry the same DTensor metadata
         (mesh, placements) as their corresponding parameters. Without this,
         DCP treats local shards as replicated data and scrambles them on load.
+
+        For state tensors whose local shape matches the param's local shape,
+        we pass ``shape`` and ``stride`` explicitly so wrapping is correct for
+        both even and uneven shards — ``DTensor.from_local``'s default global
+        shape inference (``local_size * world_size``) is only right for even
+        splits. For tensors with a different layout (e.g. quantized state,
+        which has its own packed shape), we fall back to default inference.
         """
         if not hasattr(param, "device_mesh"):
             return
@@ -636,20 +643,7 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
 
         mesh = param.device_mesh
         placements = param.placements
-
-        # Reject uneven shards - DTensor.from_local infers global shape as
-        # local_size * world_size, which is only correct for even splits.
-        #
-        # In full-state-dict export paths, leaving tensors unwrapped is still
-        # preferable to raising here, since the caller may only need a regular
-        # gathered state dict. We therefore bail out silently for uneven shards
-        # instead of failing checkpoint saving entirely.
-        for mesh_dim, placement in enumerate(placements):
-            if hasattr(placement, "dim"):
-                shard_dim = placement.dim
-                mesh_size = mesh.size(mesh_dim)
-                if param.shape[shard_dim] % mesh_size != 0:
-                    return
+        param_local_shape = param.to_local().shape
 
         for key, val in state.items():
             if (
@@ -657,7 +651,17 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
                 and not isinstance(val, DTensor)
                 and val.dim() > 0
             ):
-                state[key] = DTensor.from_local(val, mesh, placements)
+                if val.shape == param_local_shape:
+                    state[key] = DTensor.from_local(
+                        val,
+                        mesh,
+                        placements,
+                        shape=param.shape,
+                        stride=param.stride(),
+                        run_check=False,
+                    )
+                else:
+                    state[key] = DTensor.from_local(val, mesh, placements)
 
     def _recompute_stats_for_param(self, p: torch.Tensor) -> None:
         p_for_stats = self._get_tensor_for_stats(p)

--- a/flashoptim/optimizers.py
+++ b/flashoptim/optimizers.py
@@ -630,12 +630,15 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         (mesh, placements) as their corresponding parameters. Without this,
         DCP treats local shards as replicated data and scrambles them on load.
 
-        For state tensors whose local shape matches the param's local shape,
-        we pass ``shape`` and ``stride`` explicitly so wrapping is correct for
-        both even and uneven shards — ``DTensor.from_local``'s default global
-        shape inference (``local_size * world_size``) is only right for even
-        splits. For tensors with a different layout (e.g. quantized state,
-        which has its own packed shape), we fall back to default inference.
+        For state tensors whose local shape matches the param's local shape
+        (e.g. uncompressed momentum/variance), we pass ``shape`` and ``stride``
+        explicitly so wrapping is correct for both even and uneven shards —
+        ``DTensor.from_local``'s default global-shape inference (which
+        multiplies each sharded dim's local size by its mesh-dim size) is only
+        right for even splits. For tensors with a different layout (e.g.
+        quantized state, which has its own packed shape), we fall back to
+        default inference; that path is only correct for even shards, which
+        is a known limitation outside this function's scope.
         """
         if not hasattr(param, "device_mesh"):
             return

--- a/flashoptim/optimizers.py
+++ b/flashoptim/optimizers.py
@@ -1055,6 +1055,14 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         # FSDP2 support: state tensors must be created from local tensors, not DTensors.
         # This ensures each rank has state for its local parameter shard.
         p_local = self._get_local_tensor(p)
+        if not p_local.is_cuda:
+            raise ValueError(
+                "FlashOptim requires parameter shards to be on CUDA at optimizer "
+                "step time. Detected a CPU shard while initializing optimizer "
+                "state, which usually means FSDP2 or ZeRO CPU offload is enabled. "
+                "Disable CPU parameter offload to use FlashOptim, for example "
+                "set fsdp_offload_params: false."
+            )
 
         quantize = hparams.get("quantize", self._quantize)
         for key_quant, spec in self._quantized_state_spec().items():

--- a/flashoptim/optimizers.py
+++ b/flashoptim/optimizers.py
@@ -615,6 +615,19 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
             return tensor.to_local()
         return tensor
 
+    @classmethod
+    def _state_key_token(cls, tensor: torch.Tensor) -> tuple[int, int]:
+        """Build a stable token for matching optimizer state to current params.
+
+        FSDP2 can swap optimizer param-group entries to new DTensor objects whose
+        local shards alias the same storage. Matching only on Python object id is
+        too strict for checkpoint export, while matching only on storage pointer
+        is too loose for non-tensor keys. We use both local shard pointer and
+        numel to keep the matching stable across these rewrites.
+        """
+        local = cls._get_local_tensor(tensor)
+        return (local.data_ptr(), local.numel())
+
     @staticmethod
     def _wrap_state_as_dtensor(state: dict[str, Any], param: torch.Tensor) -> None:
         """Wrap plain state tensors as DTensors matching param's distribution.
@@ -632,18 +645,17 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
 
         # Reject uneven shards — DTensor.from_local infers global shape as
         # local_size * world_size, which is only correct for even splits.
+        #
+        # In full-state-dict export paths, leaving tensors unwrapped is still
+        # preferable to raising here, since the caller may only need a regular
+        # gathered state dict. We therefore bail out silently for uneven shards
+        # instead of failing checkpoint saving entirely.
         for mesh_dim, placement in enumerate(placements):
             if hasattr(placement, "dim"):
                 shard_dim = placement.dim
                 mesh_size = mesh.size(mesh_dim)
                 if param.shape[shard_dim] % mesh_size != 0:
-                    raise ValueError(
-                        f"DCP checkpointing requires evenly-sharded parameters, "
-                        f"but parameter with shape {param.shape} is unevenly "
-                        f"sharded on dim {shard_dim} across {mesh_size} ranks. "
-                        f"Pad or reshape the parameter so that shape[{shard_dim}] "
-                        f"is divisible by {mesh_size}."
-                    )
+                    return
 
         for key, val in state.items():
             if (
@@ -872,6 +884,9 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         hparams: dict[str, Any],
         idx_to_param: dict[int, torch.Tensor],
     ) -> dict[str, Any]:
+        if param_number not in opt_state:
+            return {}
+
         # Make a copy so that we don't mutate our self.state. `opt_state`
         # isn't the same as self.state, but its consituent dicts are
         # the same as those in self.state; i.e., `opt_state[p] is self.state[p]`
@@ -949,9 +964,39 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         super().__setstate__(state)
 
     def state_dict(self):
-        d = super().state_dict()
-        opt_state = d["state"]
-        param_groups = d["param_groups"]
+        for pre_hook in self._optimizer_state_dict_pre_hooks.values():
+            pre_hook(self)
+
+        param_mappings: dict[int, int] = {}
+        param_tokens: dict[tuple[int, int], int] = {}
+        start_index = 0
+
+        def pack_group(group: dict[str, Any]) -> dict[str, Any]:
+            nonlocal start_index
+            packed = {k: v for k, v in group.items() if k != "params"}
+            packed_params = []
+            for p in group["params"]:
+                idx = param_mappings.setdefault(id(p), start_index)
+                param_tokens.setdefault(self._state_key_token(p), idx)
+                packed_params.append(idx)
+                if idx == start_index:
+                    start_index += 1
+            packed["params"] = packed_params
+            return packed
+
+        param_groups = [pack_group(g) for g in self.param_groups]
+        opt_state = {}
+
+        for key, value in self.state.items():
+            if isinstance(key, torch.Tensor):
+                idx = param_mappings.get(id(key))
+                if idx is None:
+                    idx = param_tokens.get(self._state_key_token(key))
+                if idx is None:
+                    continue
+                opt_state[idx] = value
+            else:
+                opt_state[key] = value
 
         # Build param index -> param mapping without mutating self.state
         idx_to_param: dict[int, torch.Tensor] = {}
@@ -962,14 +1007,25 @@ class FlashOptimizer(torch.optim.Optimizer, abc.ABC):
         for group in param_groups:
             for param_number in group["params"]:
                 assert isinstance(param_number, int)
-                opt_state[param_number] = self._state_dict_for_param(
+                param_state = self._state_dict_for_param(
                     param_number,
                     opt_state=opt_state,
                     hparams=group,
                     idx_to_param=idx_to_param,
                 )
+                if param_state:
+                    opt_state[param_number] = param_state
 
-        return d
+        state_dict = {
+            "state": opt_state,
+            "param_groups": param_groups,
+        }
+
+        for post_hook in self._optimizer_state_dict_post_hooks.values():
+            hook_result = post_hook(self, state_dict)
+            if hook_result is not None:
+                state_dict = hook_result
+        return state_dict
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         """Load optimizer state, ensuring backward compatibility with vanilla PyTorch optimizers.

--- a/test/test_fsdp2.py
+++ b/test/test_fsdp2.py
@@ -1132,3 +1132,132 @@ def test_fsdp2_dcp_training_continuation(
         str(tmp_path / "ckpt"),
         seed,
     )
+
+
+# ============================================================================
+# FSDP2 uneven-shard state_dict test
+# ============================================================================
+
+
+def _run_fsdp2_uneven_shard_state_dict(
+    rank: int,
+    world_size: int,
+    ckpt_dir: str,
+    seed: int,
+) -> None:
+    """Unevenly sharded params: global shape not divisible by world_size.
+
+    Verifies that optimizer state tensors are wrapped as DTensors whose global
+    shape matches the param's global shape — not ``local_size * world_size``,
+    which ``DTensor.from_local``'s default inference would produce — and that
+    DCP save + load round-trips exactly.
+    """
+    import torch.distributed.checkpoint as dcp
+    from torch.distributed.checkpoint.state_dict import (
+        get_optimizer_state_dict,
+        set_optimizer_state_dict,
+    )
+    from torch.distributed.tensor import DTensor
+
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    # Shapes chosen so no dim divides evenly by world_size=2:
+    #   Linear(10, 7) -> weight [7, 10], bias [7]
+    #   Linear(7, 5)  -> weight [5, 7],  bias [5]
+    d_in, d_out, hidden_dim = 10, 5, 7
+    dtype = torch.bfloat16
+    lr = 0.001
+
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    model = _create_simple_model(d_in, d_out, hidden_dim=hidden_dim).to(
+        device=device, dtype=dtype
+    )
+    dist.barrier()
+    fully_shard(model)
+
+    # Capture global param shapes for later correctness checks.
+    param_shapes = {name: tuple(p.shape) for name, p in model.named_parameters()}
+
+    # Sanity: at least one param must be unevenly sharded on its sharded dim.
+    uneven_seen = any(
+        p.shape[placement.dim] % p.device_mesh.size(mesh_dim) != 0
+        for p in model.parameters()
+        if isinstance(p, DTensor)
+        for mesh_dim, placement in enumerate(p.placements)
+        if hasattr(placement, "dim")
+    )
+    assert uneven_seen, "Test setup failed: no uneven shards produced"
+
+    opt = ADAMW_CONFIG.factory(
+        model.parameters(),
+        lr=lr,
+        compress_state_dict=False,
+        master_weight_bits=None,
+    )
+    loss_fn = nn.MSELoss()
+
+    g = torch.Generator(device=device).manual_seed(seed + rank)
+    for _ in range(3):
+        x = torch.randn(4, d_in, device=device, dtype=dtype, generator=g)
+        y = torch.randn(4, d_out, device=device, dtype=dtype, generator=g)
+        loss_fn(model(x), y).backward()
+        opt.step()
+        opt.zero_grad(set_to_none=True)
+
+    # --- Verify wrapped DTensors carry the correct global shape ---
+    saved_osd = get_optimizer_state_dict(model, opt)
+    for fqn, param_state in saved_osd["state"].items():
+        expected_shape = param_shapes[fqn]
+        for key, val in param_state.items():
+            if isinstance(val, DTensor) and val.dim() > 0:
+                assert tuple(val.shape) == expected_shape, (
+                    f"[Rank {rank}] state[{fqn}].{key} wrapped with global shape "
+                    f"{tuple(val.shape)}, expected {expected_shape}"
+                )
+
+    # --- DCP save + load roundtrip ---
+    dcp.save({"optimizer": saved_osd}, checkpoint_id=ckpt_dir)
+    dist.barrier()
+
+    loaded_osd = get_optimizer_state_dict(model, opt)
+    dcp.load({"optimizer": loaded_osd}, checkpoint_id=ckpt_dir)
+
+    for fqn in saved_osd["state"]:
+        for key in saved_osd["state"][fqn]:
+            v_saved = saved_osd["state"][fqn][key]
+            v_loaded = loaded_osd["state"][fqn][key]
+            if isinstance(v_saved, torch.Tensor) and v_saved.dim() > 0:
+                vs = v_saved.to_local() if hasattr(v_saved, "to_local") else v_saved
+                vl = v_loaded.to_local() if hasattr(v_loaded, "to_local") else v_loaded
+                assert torch.equal(vs, vl), (
+                    f"[Rank {rank}] state[{fqn}].{key} changed after "
+                    f"DCP roundtrip: max diff = "
+                    f"{(vs.float() - vl.float()).abs().max().item()}"
+                )
+
+    set_optimizer_state_dict(model, opt, loaded_osd)
+
+    x = torch.randn(4, d_in, device=device, dtype=dtype)
+    y = torch.randn(4, d_out, device=device, dtype=dtype)
+    loss_fn(model(x), y).backward()
+    opt.step()
+    opt.zero_grad(set_to_none=True)
+
+    del model, opt
+    torch.cuda.empty_cache()
+    dist.barrier()
+
+
+@pytest.mark.parametrize("seed", [0], ids=lambda s: f"seed{s}")
+def test_fsdp2_uneven_shard_state_dict(
+    seed: int,
+    fsdp2_runner,
+    tmp_path,
+) -> None:
+    fsdp2_runner(
+        _run_fsdp2_uneven_shard_state_dict,
+        str(tmp_path / "ckpt"),
+        seed,
+    )

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -218,6 +218,21 @@ def test_state_dict_save_load(
 _CKPT_SEEDS = [0, 1]
 
 
+def test_state_dict_before_first_step_matches_torch_empty_state():
+    """Accelerate inspects optimizer state before the first step during prepare()."""
+    params = [
+        torch.nn.Parameter(torch.randn(8, device="cuda", dtype=torch.bfloat16)),
+        torch.nn.Parameter(torch.randn(4, device="cuda", dtype=torch.bfloat16)),
+    ]
+
+    opt = ADAMW_CONFIG.factory(params, lr=1e-3)
+    state_dict = opt.state_dict()
+
+    assert state_dict["state"] == {}
+    assert len(state_dict["param_groups"]) == 1
+    assert state_dict["param_groups"][0]["params"] == [0, 1]
+
+
 @pytest.mark.parametrize("seed", _CKPT_SEEDS, ids=seed_id)
 @pytest.mark.parametrize("ckpt_config", _CKPT_CONFIGS, ids=ckpt_id)
 @pytest.mark.parametrize(

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -233,6 +233,16 @@ def test_state_dict_before_first_step_matches_torch_empty_state():
     assert state_dict["param_groups"][0]["params"] == [0, 1]
 
 
+def test_cpu_offloaded_param_raises_helpful_error():
+    """CPU-offloaded shards should fail early with a targeted message."""
+    param = torch.nn.Parameter(torch.randn(16, device="cpu", dtype=torch.bfloat16))
+    param.grad = torch.randn_like(param)
+
+    opt = ADAMW_CONFIG.factory([param], lr=1e-3)
+    with pytest.raises(ValueError, match="requires parameter shards to be on CUDA"):
+        opt.step()
+
+
 @pytest.mark.parametrize("seed", _CKPT_SEEDS, ids=seed_id)
 @pytest.mark.parametrize("ckpt_config", _CKPT_CONFIGS, ids=ckpt_id)
 @pytest.mark.parametrize(


### PR DESCRIPTION
  Fixes two small FSDP2/Accelerate interop issues in FlashOptim when used through   HF Trainer / TRL / Accelerate. Since v0.1.4 landed on main (which added the  frozen-param `continue` in `state_dict()`), the pre-first-step case is already  handled upstream — this PR now only carries the remaining gaps.

 ## Summary

  - **Uneven-shard fallback during full-state-dict export.** `_wrap_state_as_dtensor`    previously raised `ValueError` on unevenly sharded parameters. In FSDP2    `FULL_STATE_DICT` export (accelerate/utils/fsdp_utils.py), the caller only     needs a gathered state dict — not DCP-ready DTensors — so the raise aborted    valid exports. Now the function silently returns, leaving tensors unwrapped    (still a correct gathered export).
  - **Clearer error for CPU-offloaded shards.** FlashOptim's quantized state and    fused CUDA kernels require CUDA-resident shards at step time. Previously, a    CPU-offloaded shard (e.g. `fsdp_offload_params: true`) crashed with an opaque     kernel error during `step()`. Now `_ensure_state_initialized` raises a    targeted `ValueError` pointing at `fsdp_offload_params: false`.
  - **Regression test for Accelerate `prepare()`.** Pins that    `FlashOptimizer.state_dict()` on a never-stepped optimizer returns    `{"state": {}, "param_groups": [...]}` matching vanilla AdamW. Accelerate's    `AcceleratedOptimizer.__init__` calls `optimizer.state_dict()` during     `accelerator.prepare()` (to move state to the correct device) — this test    guards against regressing that contract.

 ## Why

  Single-GPU training worked, but FSDP2 checkpointing through Trainer/TRL/   Accelerate exposed two serialization assumptions that don't hold in   distributed preparation: (a) unevenly sharded parameters can make DTensor   wrapping impossible even when a valid full-state export is still possible,   and (b) CPU-offloaded shards are not a meaningful FlashOptim mode and   previously failed with a low-level quantization error instead of a clear   incompatibility message.

  ## Caveats

  - Uneven-shard handling now favors successful full-state-compatible export    over strict DTensor wrapping for that case.
  - CPU-offloaded parameter shards remain unsupported; this PR only improves    the error message.
